### PR TITLE
Fix API key setup in notebook

### DIFF
--- a/GPT-Bulk-Marketing-Email-Generator.ipynb
+++ b/GPT-Bulk-Marketing-Email-Generator.ipynb
@@ -33,10 +33,14 @@
    "source": [
     "#Imports\n",
     "import openai\n",
+    "import os\n",
     "import csv\n",
     "from docx import Document\n",
     "#Add your openAI Key here. You can generate your key by signing up https://openai.com/\n",
-    "openai.api_key  = <YOUR_OPENAI_KEY>"
+    "openai_api_key = os.getenv('OPENAI_API_KEY')\n",
+    "if not openai_api_key:\n",
+    "    raise ValueError('OPENAI_API_KEY environment variable not set')\n",
+    "openai.api_key = openai_api_key\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- ensure OpenAI API key placeholder is loaded from environment
- check that the environment variable is set and raise helpful error

## Testing
- `python3 -m json.tool GPT-Bulk-Marketing-Email-Generator.ipynb | sed -n '30,50p'`
- `python3 - <<'PY'
import csv
from docx import Document
import os
with open('dummy_businesses.csv', newline='') as f:
    reader=csv.DictReader(f)
    for row in reader:
        pass
print('csv ok')
PY` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_68544ce8604483308ad7260960ff82d0